### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,271 +1,117 @@
-# Run Selenium Tests With Node.js — TestMu AI (Formerly LambdaTest)
+# Run Selenium Tests with Node.js on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
-<img height="500" src="https://user-images.githubusercontent.com/95698164/172000250-2a4e49e5-ec0b-452a-b1bc-3674e75ecd76.png">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.npmjs.com/package/selenium-webdriver"><img src="https://img.shields.io/npm/v/selenium-webdriver.svg?style=for-the-badge&labelColor=000000" alt="selenium-webdriver version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
 
-<p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
-</p>
-&emsp;
-&emsp;
-&emsp;
+## Getting Started
 
-*Learn how to use Node.js environment to configure and run your JavaScript automation testing scripts on the [TestMu AI Selenium cloud platform](https://www.testmuai.com/selenium-automation/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample).*
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
+With TestMu AI (Formerly LambdaTest), you can run Selenium tests in Node.js across real browsers and operating systems. This sample shows how to configure Node.js Selenium WebDriver to run on the TestMu AI cloud.
 
-## Table of Contents
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
-* [Pre-requisites](#pre-requisites)
-* [Run Your First Test](#run-your-first-test)
-* [Executing The Test](#executing-the-test)
-* [Testing Locally Hosted or Privately Hosted Projects](#testing-locally-hosted-or-privately-hosted-projects)
+### Prerequisites
 
-## Pre-requisites
+- Node.js and npm (latest stable)
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-Before getting started with Selenium automation testing on TestMu AI, you need to:
+### Setup
 
-* Download and install **NodeJS**. You should be having **NodeJS v6 to NodeJS v16**. Click [here](https://nodejs.org/en/) to download.
-* Make sure you are using the latest version of **JavaScript**.
-* Install **npm** from the official website by clicking [here](https://www.npmjs.com/).
-* Download [Selenium JavaScript bindings](https://www.selenium.dev/downloads/) from the official website. Latest versions of **Selenium Client** and **WebDriver** are ideal for running your JavaScript automation testing script on TestMu AI’s Selenium Grid.
-
-### Installing Selenium Dependencies and tutorial repo
-
-Clone the TestMu AI’s [nodejs-selenium-sample](https://github.com/LambdaTest/nodejs-selenium-sample) repository and navigate to the code directory as shown below:
+Clone and install dependencies:
 
 ```bash
-git clone https://github.com/LambdaTest/nodejs-selenium-sample
-cd nodejs-selenium-sample
-```
-You need to install the following dependencies to your `package.json` file: 
-
-You will need to install the `selenium webdriver` to make the connection to the `GRID`: 
-
-```bash
+git clone https://github.com/LambdaTest/nodejs-selenium-sample && cd nodejs-selenium-sample
 npm install selenium-webdriver
 ```
 
-Create a new file as `index.js` in your current project or the sample folder and add the below code snippet which will call the installed driver. 
+Set your credentials as environment variables.
 
-```js
-// index.js
-const webdriver = require('selenium-webdriver');
-```
-
-### Setting up Your Authentication
-
-Make sure you have your TestMu AI credentials with you to run test automation scripts on TestMu AI Selenium Grid. You can obtain these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) or through [TestMu AI Profile](https://accounts.lambdatest.com/login/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample).
-
-Set TestMu AI `Username` and `Access Key` in environment variables.
-
-  * For **Linux/macOS**:
-  ```bash
-  export LT_USERNAME="YOUR_USERNAME" export LT_ACCESS_KEY="YOUR ACCESS KEY"
-  ```
-  * For **Windows**:
-  ```bash
-  set LT_USERNAME="YOUR_USERNAME" set LT_ACCESS_KEY="YOUR ACCESS KEY"
-  ```
-
-### Connecting to The Cloud Grid
-
-Now you can add the `GRID HOST` which is used to connect your current test suites to be executed on the cloud grid. 
-
-```js
-// index.js
-// username: Username can be found at automation dashboard
-const username = process.env.LT_USERNAME;
-
-// AccessKey:  AccessKey can be generated from automation dashboard or profile section
-const accessKey = process.env.LT_ACCESS_KEY;
-
-const gridUrl = 'https://' + username + ':' + accessKey + '@hub.lambdatest.com/wd/hub';
-
-    // Setup and build selenium driver object
-    const driver = new webdriver.Builder()
-        .usingServer(gridUrl)
-        .withCapabilities(capabilities)
-        .build();
-
-```
-The above grid connect will create the `Webdriver` for the test suite to execute the `Selenium` commands for your test. 
-
-## Run Your First Test
-
-### Configuration of Your Test Capabilities
-
-In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with TestMu AI Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
-
-```js
-// index.js
-// Setup capabilities, Know more about LamdbdaTest Capabilities: https://www.lambdatest.com/capabilities-generator/
-    const capabilities = {
-        "browserName": "Chrome",
-        // "browserVersion": "latest", #Uncomment to Specify Browser Version 
-        "LT:Options": {
-            name: 'NodeJS Get Set Go', // name of the test
-            build: 'NodeJS Loves LambdaTest', // name of the build
-            "project": "Build-With-LambdaTtest",
-            "w3c": true,
-            "plugin": "NodeJS",
-            "customData": {
-                "buildNumber": "1234",
-                "environment": "Staging",
-                "apiVersion": "v1.2.3",
-                "releaseTag": "v1.2.3-rc1"
-            },
-
-        }
-```
-> **Note:** You can generate capabilities for your test requirements with the help of our inbuilt **[Capabilities Generator tool](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)**.
-
-### Writing your Test Cases
-
-Now you write your selenium test cases in your `index.js` file:
-
-```js
-async function todoTest() {
-   try {
-        // Navigate to a URL, click on the first and second list items and add a new one in the list.
-        await driver.get('https://lambdatest.github.io/sample-todo-app/');
-        await driver.findElement(webdriver.By.name('li1')).click();
-        console.log("Successfully clicked first list item.");
-        await driver.findElement(webdriver.By.name('li2')).click();
-        console.log("Successfully clicked second list item.");
-
-        await driver.findElement(webdriver.By.id('sampletodotext')).sendKeys('Complete Lambdatest Tutorial\n');
-        await driver.findElement(webdriver.By.id('addbutton')).click();
-        console.log("Successfully added a new task.");
-        await driver.executeScript('lambda-status=passed');
-    } catch (err) {
-        console.log("test failed with reason " + err);
-        await driver.executeScript('lambda-status=failed');
-    } finally {
-        await driver.quit();
-    }
-}
-
-todoTest();
-```
-
-## Executing the Test
-
-Please execute the following command below to run your tests: 
+**macOS / Linux:**
 
 ```bash
-npm test OR node index.js
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
-Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [TestMu AI automation dashboard](https://automation.lambdatest.com/build/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample). TestMu AI Automation Dashboard will help you view all your text logs, screenshots and video recording for your entire automation tests.
 
-## Testing Locally Hosted or Privately Hosted Projects
+**Windows:**
 
-You can test your locally hosted or privately hosted projects with [TestMu AI Selenium grid cloud](https://www.testmuai.com/selenium-automation/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) using TestMu AI Tunnel app. All you would have to do is set up an SSH tunnel using TestMu AI Tunnel app and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are made live.
-
->Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/) for more information.
-
-Here’s how you can establish TestMu AI Tunnel.
-
->Download the binary file of:
-* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [TestMu AI Tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
-
-Open command prompt and navigate to the binary folder.
-
-Run the following command:
 ```bash
-LT -user {user’s login email} -key {user’s access key}
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
 ```
-So if your user name is lambdatest@example.com and key is 123456, the command would be:
-```bash
-LT -user lambdatest@example.com -key 123456
-```
-Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
 
-**Tunnel Capability**
+### Run tests
+
+```bash
+npm test
+```
+
+Or:
+
+```bash
+node index.js
+```
+
+View results on your TestMu AI dashboard.
+
+### Local testing with TestMu AI Tunnel
+
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
+
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+Add the following to your capabilities:
+
 ```js
-const capabilities = {
-        tunnel: true,
-}
+tunnel: true,
 ```
 
-## Additional Links
+## Contributions
 
-* [Advanced Configuration for Capabilities](https://www.testmuai.com/support/docs/selenium-automation-capabilities/)
-* [How to test locally hosted apps](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/)
-* [How to integrate TestMu AI with CI/CD](https://www.testmuai.com/support/docs/integrations-with-ci-cd-tools/)
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Node.js version, OS, and selenium-webdriver version.
 
-## Tutorials 📙
+## TestMu AI (Formerly LambdaTest) Community
 
-Check out our latest tutorials on JavaScript automation testing 👇
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-* [How To Perform Modern Web Testing With TestCafe Using JavaScript And Selenium](https://www.testmuai.com/blog/modern-web-testing-with-testcafe/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Implement Drag And Drop In JavaScript Using Selenium?](https://www.testmuai.com/blog/how-to-implement-drag-and-drop-in-javascript/#:~:text=Launch%20the%20browser.,Close%20the%20browser./?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Automation Testing with Selenium JavaScript [Tutorial]](https://www.testmuai.com/blog/automation-testing-with-selenium-javascript/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Best 9 JavaScript Testing Frameworks](https://www.testmuai.com/blog/top-javascript-automation-testing-framework/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Jest vs Mocha vs Jasmine: Comparing The Top 3 JavaScript Testing Frameworks](https://www.testmuai.com/blog/jest-vs-mocha-vs-jasmine/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Use JavaScript Wait Function In Selenium WebDriver](https://www.testmuai.com/blog/javascript-wait-in-selenium-webdriver/#SeleniumWebDriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Jest Tutorial For Selenium JavaScript Testing With Examples](https://www.testmuai.com/blog/jest-tutorial-for-selenium-javascript-testing-with-examples/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Cucumber.js Tutorial with Examples For Selenium JavaScript](https://www.testmuai.com/blog/cucumberjs-tutorial-selenium/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Mocha JavaScript Tutorial With Examples For Selenium Testing](https://www.testmuai.com/blog/mocha-javascript-tutorial-with-examples-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Get Data Of Attributes In JavaScript With Selenium](https://www.testmuai.com/blog/how-to-get-data-of-attributes-in-javascript-with-selenium/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Take Screenshots In Selenium WebDriver Using JavaScript](https://www.testmuai.com/blog/taking-screenshots-in-selenium-webdriver-using-javascript/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Use Strings In JavaScript With Selenium WebDriver](https://www.testmuai.com/blog/using-strings-in-javascript-using-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Use JavaScript Wait Function In Selenium WebDriver](https://www.testmuai.com/blog/javascript-wait-in-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-## Documentation & Resources :books:
-      
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)    
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-## TestMu AI Community :busts_in_silhouette:
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-## What's New At TestMu AI ❓
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
 
-## 🚀 LambdaTest is Now TestMu AI
+### How LambdaTest Evolved into TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-### 🔄 Our Rebrand Journey
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+## Support
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
-
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
-
-### 🔭 Explore TestMu AI
-
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -247,13 +247,19 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-# Run Selenium Tests With Node.js On LambdaTest 
+# Run Selenium Tests With Node.js — TestMu AI (Formerly LambdaTest)
 
 <p align="center">
 <img height="500" src="https://user-images.githubusercontent.com/95698164/172000250-2a4e49e5-ec0b-452a-b1bc-3674e75ecd76.png">
 </p>
 
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to use Node.js environment to configure and run your JavaScript automation testing scripts on the [LambdaTest Selenium cloud platform](https://www.lambdatest.com/selenium-automation/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample).*
+*Learn how to use Node.js environment to configure and run your JavaScript automation testing scripts on the [TestMu AI Selenium cloud platform](https://www.testmuai.com/selenium-automation/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample).*
 
 [<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
 
@@ -34,16 +34,16 @@
 
 ## Pre-requisites
 
-Before getting started with Selenium automation testing on LambdaTest, you need to:
+Before getting started with Selenium automation testing on TestMu AI, you need to:
 
 * Download and install **NodeJS**. You should be having **NodeJS v6 to NodeJS v16**. Click [here](https://nodejs.org/en/) to download.
 * Make sure you are using the latest version of **JavaScript**.
 * Install **npm** from the official website by clicking [here](https://www.npmjs.com/).
-* Download [Selenium JavaScript bindings](https://www.selenium.dev/downloads/) from the official website. Latest versions of **Selenium Client** and **WebDriver** are ideal for running your JavaScript automation testing script on LambdaTest’s Selenium Grid.
+* Download [Selenium JavaScript bindings](https://www.selenium.dev/downloads/) from the official website. Latest versions of **Selenium Client** and **WebDriver** are ideal for running your JavaScript automation testing script on TestMu AI’s Selenium Grid.
 
 ### Installing Selenium Dependencies and tutorial repo
 
-Clone the LambdaTest’s [nodejs-selenium-sample](https://github.com/LambdaTest/nodejs-selenium-sample) repository and navigate to the code directory as shown below:
+Clone the TestMu AI’s [nodejs-selenium-sample](https://github.com/LambdaTest/nodejs-selenium-sample) repository and navigate to the code directory as shown below:
 
 ```bash
 git clone https://github.com/LambdaTest/nodejs-selenium-sample
@@ -66,9 +66,9 @@ const webdriver = require('selenium-webdriver');
 
 ### Setting up Your Authentication
 
-Make sure you have your LambdaTest credentials with you to run test automation scripts on LambdaTest Selenium Grid. You can obtain these credentials from the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/build/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) or through [LambdaTest Profile](https://accounts.lambdatest.com/login/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample).
+Make sure you have your TestMu AI credentials with you to run test automation scripts on TestMu AI Selenium Grid. You can obtain these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/build/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) or through [TestMu AI Profile](https://accounts.lambdatest.com/login/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample).
 
-Set LambdaTest `Username` and `Access Key` in environment variables.
+Set TestMu AI `Username` and `Access Key` in environment variables.
 
   * For **Linux/macOS**:
   ```bash
@@ -106,7 +106,7 @@ The above grid connect will create the `Webdriver` for the test suite to execute
 
 ### Configuration of Your Test Capabilities
 
-In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with LambdaTest Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
+In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with TestMu AI Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
 
 ```js
 // index.js
@@ -129,7 +129,7 @@ In the test script, you need to update your test capabilities. In this code, we 
 
         }
 ```
-> **Note:** You can generate capabilities for your test requirements with the help of our inbuilt **[Capabilities Generator tool](https://www.lambdatest.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)**.
+> **Note:** You can generate capabilities for your test requirements with the help of our inbuilt **[Capabilities Generator tool](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)**.
 
 ### Writing your Test Cases
 
@@ -167,20 +167,20 @@ Please execute the following command below to run your tests:
 ```bash
 npm test OR node index.js
 ```
-Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [LambdaTest automation dashboard](https://automation.lambdatest.com/build/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample). LambdaTest Automation Dashboard will help you view all your text logs, screenshots and video recording for your entire automation tests.
+Your test results would be displayed on the test console (or command-line interface if you are using terminal/cmd) and on [TestMu AI automation dashboard](https://automation.lambdatest.com/build/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample). TestMu AI Automation Dashboard will help you view all your text logs, screenshots and video recording for your entire automation tests.
 
 ## Testing Locally Hosted or Privately Hosted Projects
 
-You can test your locally hosted or privately hosted projects with [LambdaTest Selenium grid cloud](https://www.lambdatest.com/selenium-automation/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) using LambdaTest Tunnel app. All you would have to do is set up an SSH tunnel using LambdaTest Tunnel app and pass toggle `tunnel = True` via desired capabilities. LambdaTest Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are made live.
+You can test your locally hosted or privately hosted projects with [TestMu AI Selenium grid cloud](https://www.testmuai.com/selenium-automation/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) using TestMu AI Tunnel app. All you would have to do is set up an SSH tunnel using TestMu AI Tunnel app and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are made live.
 
->Refer our [LambdaTest Tunnel documentation](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/) for more information.
+>Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/) for more information.
 
-Here’s how you can establish LambdaTest Tunnel.
+Here’s how you can establish TestMu AI Tunnel.
 
 >Download the binary file of:
-* [LambdaTest Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [LambdaTest Tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [LambdaTest Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
+* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
+* [TestMu AI Tunnel for Mac](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
+* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
 
 Open command prompt and navigate to the binary folder.
 
@@ -192,7 +192,7 @@ So if your user name is lambdatest@example.com and key is 123456, the command wo
 ```bash
 LT -user lambdatest@example.com -key 123456
 ```
-Once you are able to connect **LambdaTest Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
+Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
 
 **Tunnel Capability**
 ```js
@@ -203,66 +203,59 @@ const capabilities = {
 
 ## Additional Links
 
-* [Advanced Configuration for Capabilities](https://www.lambdatest.com/support/docs/selenium-automation-capabilities/)
-* [How to test locally hosted apps](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/)
-* [How to integrate LambdaTest with CI/CD](https://www.lambdatest.com/support/docs/integrations-with-ci-cd-tools/)
+* [Advanced Configuration for Capabilities](https://www.testmuai.com/support/docs/selenium-automation-capabilities/)
+* [How to test locally hosted apps](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/)
+* [How to integrate TestMu AI with CI/CD](https://www.testmuai.com/support/docs/integrations-with-ci-cd-tools/)
 
 ## Tutorials 📙
 
 Check out our latest tutorials on JavaScript automation testing 👇
 
-* [How To Perform Modern Web Testing With TestCafe Using JavaScript And Selenium](https://www.lambdatest.com/blog/modern-web-testing-with-testcafe/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Implement Drag And Drop In JavaScript Using Selenium?](https://www.lambdatest.com/blog/how-to-implement-drag-and-drop-in-javascript/#:~:text=Launch%20the%20browser.,Close%20the%20browser./?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Automation Testing with Selenium JavaScript [Tutorial]](https://www.lambdatest.com/blog/automation-testing-with-selenium-javascript/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Best 9 JavaScript Testing Frameworks](https://www.lambdatest.com/blog/top-javascript-automation-testing-framework/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Jest vs Mocha vs Jasmine: Comparing The Top 3 JavaScript Testing Frameworks](https://www.lambdatest.com/blog/jest-vs-mocha-vs-jasmine/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Use JavaScript Wait Function In Selenium WebDriver](https://www.lambdatest.com/blog/javascript-wait-in-selenium-webdriver/#SeleniumWebDriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Jest Tutorial For Selenium JavaScript Testing With Examples](https://www.lambdatest.com/blog/jest-tutorial-for-selenium-javascript-testing-with-examples/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Cucumber.js Tutorial with Examples For Selenium JavaScript](https://www.lambdatest.com/blog/cucumberjs-tutorial-selenium/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [Mocha JavaScript Tutorial With Examples For Selenium Testing](https://www.lambdatest.com/blog/mocha-javascript-tutorial-with-examples-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Get Data Of Attributes In JavaScript With Selenium](https://www.lambdatest.com/blog/how-to-get-data-of-attributes-in-javascript-with-selenium/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Take Screenshots In Selenium WebDriver Using JavaScript](https://www.lambdatest.com/blog/taking-screenshots-in-selenium-webdriver-using-javascript/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Use Strings In JavaScript With Selenium WebDriver](https://www.lambdatest.com/blog/using-strings-in-javascript-using-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [How To Use JavaScript Wait Function In Selenium WebDriver](https://www.lambdatest.com/blog/javascript-wait-in-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [How To Perform Modern Web Testing With TestCafe Using JavaScript And Selenium](https://www.testmuai.com/blog/modern-web-testing-with-testcafe/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [How To Implement Drag And Drop In JavaScript Using Selenium?](https://www.testmuai.com/blog/how-to-implement-drag-and-drop-in-javascript/#:~:text=Launch%20the%20browser.,Close%20the%20browser./?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [Automation Testing with Selenium JavaScript [Tutorial]](https://www.testmuai.com/blog/automation-testing-with-selenium-javascript/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [Best 9 JavaScript Testing Frameworks](https://www.testmuai.com/blog/top-javascript-automation-testing-framework/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [Jest vs Mocha vs Jasmine: Comparing The Top 3 JavaScript Testing Frameworks](https://www.testmuai.com/blog/jest-vs-mocha-vs-jasmine/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [How To Use JavaScript Wait Function In Selenium WebDriver](https://www.testmuai.com/blog/javascript-wait-in-selenium-webdriver/#SeleniumWebDriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [Jest Tutorial For Selenium JavaScript Testing With Examples](https://www.testmuai.com/blog/jest-tutorial-for-selenium-javascript-testing-with-examples/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [Cucumber.js Tutorial with Examples For Selenium JavaScript](https://www.testmuai.com/blog/cucumberjs-tutorial-selenium/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [Mocha JavaScript Tutorial With Examples For Selenium Testing](https://www.testmuai.com/blog/mocha-javascript-tutorial-with-examples-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [How To Get Data Of Attributes In JavaScript With Selenium](https://www.testmuai.com/blog/how-to-get-data-of-attributes-in-javascript-with-selenium/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [How To Take Screenshots In Selenium WebDriver Using JavaScript](https://www.testmuai.com/blog/taking-screenshots-in-selenium-webdriver-using-javascript/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [How To Use Strings In JavaScript With Selenium WebDriver](https://www.testmuai.com/blog/using-strings-in-javascript-using-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [How To Use JavaScript Wait Function In Selenium WebDriver](https://www.testmuai.com/blog/javascript-wait-in-selenium-webdriver/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
 
 ## Documentation & Resources :books:
       
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)    
 
-## LambdaTest Community :busts_in_silhouette:
+## TestMu AI Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
 
-## What's New At LambdaTest ❓
+## What's New At TestMu AI ❓
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
-      
-## About LambdaTest
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-[LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
-    
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register)
-      
-## We are here to help you :headphones:
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-* Got a query? we are available 24x7 to help. [Contact Us](support@lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=nodejs-selenium-sample)
+**🔄 Our Rebrand Journey**
+
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_
 
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -251,11 +251,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code